### PR TITLE
PHP puppet now use stabile ondrej ppa repo for php 5.4

### DIFF
--- a/puppet/modules/php54/manifests/init.pp
+++ b/puppet/modules/php54/manifests/init.pp
@@ -14,7 +14,7 @@ class php54
    	exec 
 	{ 
 	    'add php54 apt-repo':
-	        command => '/usr/bin/add-apt-repository ppa:ondrej/php5 -y',
+	        command => '/usr/bin/add-apt-repository ppa:ondrej/php5-oldstable -y',
 	        require => Package['python-software-properties'],
 	}
 


### PR DESCRIPTION
The ppa repo "ppa:ondrej/php5" now by default install php 5.5 version, and provisioning breaks because of dependencies. So we have to use "ppa:ondrej/php5-oldstable" to make sure puppet will install PHP 5.4 version as we want.

This is my first pull request so if I missed something please inform me.
