### PR TITLE
Update laravel_app/manifests/init.pp

### DIFF
--- a/puppet/modules/laravel_app/manifests/init.pp
+++ b/puppet/modules/laravel_app/manifests/init.pp
@@ -22,7 +22,8 @@ class laravel_app
 	# the composer create-project is called
 	exec { 'clean www directory': 
 		command => "/bin/sh -c 'cd /var/www && find -mindepth 1 -delete'",
-		unless => [ "test -f /var/www/composer.json", "test -d /var/www/app" ]
+		unless => [ "test -f /var/www/composer.json", "test -d /var/www/app" ],
+		require => Package['apache2']
 	}
 
 


### PR DESCRIPTION
Added requirement for apache2 to be installed before Exec['clean www directory'] is ran.

When the apache2 package is installed, it places an 'index.html' file in the "/var/www/" folder, which causes the Exec['create laravel project'] to later fail (since the directory is no longer empty).

Hopefully, this will help prevent the issue from happening to others.
