### PR TITLE
Removed www Directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@ dwsync.xml
 .svn
 .CVS
 .idea
-/www/bootstrap/compiled.php
-/www/vendor
+/bootstrap/compiled.php
+/vendor
 composer.phar
 composer.lock

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,7 +14,9 @@ Vagrant.configure("2") do |config|
         lv4_config.vm.network :forwarded_port, guest: 3306, host: 8889, auto_correct: true
         lv4_config.vm.network :forwarded_port, guest: 5432, host: 5433, auto_correct: true
         lv4_config.vm.hostname = "laravel"
-        lv4_config.vm.synced_folder "www", "/var/www", {:mount_options => ['dmode=777','fmode=777']}
+        lv4_config.vm.synced_folder ".", "/vagrant", disabled: true
+        lv4_config.vm.synced_folder ".", "/var/www", {:mount_options => ['dmode=777','fmode=777']}
+        lv4_config.vm.synced_folder "puppet", "/vagrant/puppet"
         lv4_config.vm.provision :shell, :inline => "echo \"Europe/London\" | sudo tee /etc/timezone && dpkg-reconfigure --frontend noninteractive tzdata"
 
         lv4_config.vm.provider :virtualbox do |v|

--- a/www/.gitignore
+++ b/www/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore


### PR DESCRIPTION
I had an issue setting up Travis-ci where i needed the composer.json in the root of the project.

All Laravel project files are installed in the root of the project.
*The entire project gets synced to /var/www/
*The puppet directory still goes to /vagrant (for dependencies)

The only issue that I found is that the puppet directory is also copied to /var/www/ as well.
