### PR TITLE
Update php.ini.erb

### DIFF
--- a/puppet/modules/php/templates/php.ini.erb
+++ b/puppet/modules/php/templates/php.ini.erb
@@ -1823,7 +1823,7 @@ ldap.max_links = -1
 [xdebug]
 xdebug.remote_enable=1
 ;xdebug.remote_host=localhost
-xdebug.remote_port=9001
+xdebug.remote_port=9000
 xdebug.remote_autostart=0
 xdebug.remote_connect_back=1
 <% end %>

--- a/puppet/modules/php/templates/php.ini.erb
+++ b/puppet/modules/php/templates/php.ini.erb
@@ -1,4 +1,3 @@
-
 [PHP]
 
 ;;;;;;;;;;;;;;;;;;;
@@ -1825,6 +1824,6 @@ ldap.max_links = -1
 xdebug.remote_enable=1
 ;xdebug.remote_host=localhost
 xdebug.remote_port=9001
-xdebug.remote_autostart=1
+xdebug.remote_autostart=0
 xdebug.remote_connect_back=1
 <% end %>


### PR DESCRIPTION
I think setting remote_autostart to false is a more useful default for people using xdebug (and is the default setting for xdebug anyway http://xdebug.org/docs/all_settings#remote_autostart).

Most people that I know who use xdebug will specifically request it starts via a plugin or bookmarklette, so to have it automatically start is just going to be annoying.

(I'm wondering if this setting is why you've got xdebug disabled by default, because with this set to false, the pages load just as quickly as if xdebug is disabled entirely)
