### PR TITLE
Added postgresql include to manifest and a note to readme.md.

### DIFF
--- a/puppet/manifests/phpbase.pp
+++ b/puppet/manifests/phpbase.pp
@@ -24,6 +24,7 @@ include phpmyadmin
 include beanstalkd
 include redis
 include memcached
+#include postgresql
 
 include laravel_app
 

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,7 @@ Some basic information on interacting with the vagrant box
 * Password: (blank)
 * DB Name: database
 
+*To provision your machien with postgresql uncomment the line to include postgresql in [puppet/manifests/phpbase.pp](puppet/manifests/phpbase.pp#L27)*
 
 ### PHPmyAdmin
 


### PR DESCRIPTION
Minor change, there wasn't anything to make people aware that postgresql wasn't being install by default. I added a commented out line to phpbase.pp and a note to uncomment it in the readme.md to let people know how to get postgresql.
